### PR TITLE
Display real lesson images instead of placeholders

### DIFF
--- a/client/src/lib/learning-plans.ts
+++ b/client/src/lib/learning-plans.ts
@@ -46,13 +46,13 @@ export const learningPlans: LearningPlan[] = [
             title: "What is Fasting in Islam?",
             content:
               "Fasting in Islam, known as 'Sawm' in Arabic, is one of the Five Pillars of Islam. It requires Muslims to abstain from food, drink, smoking, and intimate relations from dawn until sunset during the holy month of Ramadan. Beyond physical restraint, fasting in Islam is a comprehensive spiritual exercise that engages the entire being—body, mind, and soul.\n\nThe Quran mentions fasting in Surah Al-Baqarah, verse 183: 'O you who have believed, fasting has been decreed upon you as it was decreed upon those before you that you may become righteous.'\n\nThis verse highlights that fasting isn't unique to Islam but has been a spiritual practice across many faiths throughout history. The unique aspect of Islamic fasting is its systematic approach and its role as a mandatory practice for all capable Muslims.",
-            imageUrl: "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F319.svg",
+            imageUrl: "/assets/moon.svg",
           },
           {
             title: "Historical Context",
             content:
               "Fasting was prescribed in the second year after the migration to Madinah (Hijrah), making it one of the earliest formal obligations in Islam. Before the specific commandment for Ramadan fasting, Muslims would fast on the day of Ashura (10th of Muharram), following the Jewish tradition of fasting on Yom Kippur.\n\nThe Prophet Muhammad ﷺ emphasized the importance of fasting both through his teachings and his practice. He would not only observe the obligatory fasts during Ramadan but would also keep voluntary fasts throughout the year, demonstrating the spiritual benefits beyond the obligatory period.",
-            imageUrl: "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F5FA.svg",
+            imageUrl: "/assets/world-map.svg",
           },
           {
             title: "Physical and Psychological Dimensions",
@@ -73,13 +73,13 @@ export const learningPlans: LearningPlan[] = [
             title: "Taqwa: God-Consciousness",
             content:
               "The primary spiritual benefit of fasting, as mentioned in the Quran, is the development of 'taqwa' or God-consciousness. Fasting serves as a shield, a protection against spiritual pitfalls and moral lapses. When fasting, Muslims are constantly reminded of their commitment to God, as they abstain from permissible things for His sake.\n\nThis heightened awareness of the Divine presence helps in establishing a deeper connection with the Creator. It reminds Muslims that if they can abstain from lawful desires for God's sake, they should certainly be able to abstain from unlawful actions at all times.",
-            imageUrl: "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F6E1.svg",
+            imageUrl: "/assets/shield.svg",
           },
           {
             title: "Empathy and Compassion",
             content:
               "By experiencing hunger and thirst, Muslims develop a more profound empathy for those who face these conditions not by choice but by circumstance. This firsthand experience of deprivation often leads to increased charitable giving during Ramadan.\n\nThe Prophet Muhammad ﷺ was already the most generous of people, but he would increase in generosity during Ramadan. This tradition continues today, with many Muslims amplifying their charitable activities during this month, reflecting the heightened sense of social responsibility that fasting nurtures.",
-            imageUrl: "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F91D.svg",
+            imageUrl: "/assets/empathy-illustration.svg",
           },
           {
             title: "Self-Discipline and Willpower",
@@ -100,13 +100,13 @@ export const learningPlans: LearningPlan[] = [
             title: "Mindful Eating Practices",
             content:
               "The pre-dawn meal (Suhoor) and the fast-breaking meal (Iftar) present perfect opportunities for mindful eating. Being conscious of what and how we eat not only enhances the physical benefits of fasting but also elevates its spiritual dimension.\n\nMindful eating involves giving full attention to the food—its taste, texture, and the blessing it represents. The Prophet Muhammad ﷺ advised against overeating, stating, 'The son of Adam fills no vessel worse than his stomach.' This guidance aligns with modern mindfulness practices around food consumption.",
-            imageUrl: "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F37D.svg",
+            imageUrl: "/assets/utensils.svg",
           },
           {
             title: "Meditation and Dhikr",
             content:
               "Ramadan provides an excellent opportunity to establish or deepen a meditation practice. Islamic meditation, often centered around remembrance of God (dhikr), can help maintain focus and spiritual presence throughout the fast.\n\nSimple practices like setting aside time for quiet contemplation, mindful recitation of the Quran, or engaging in dhikr can significantly enhance the spiritual experience of Ramadan. The quiet hours before dawn (during Tahajjud prayer time) are especially conducive to meditation and deep spiritual connection.",
-            imageUrl: "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F9D8.svg",
+            imageUrl: "/assets/meditation-illustration.svg",
           },
           {
             title: "Managing Emotions and Responses",
@@ -137,13 +137,13 @@ export const learningPlans: LearningPlan[] = [
             title: "The Importance of Historical Context",
             content:
               "The Quran was revealed over a period of 23 years, during which many historical events occurred. Understanding these events provides crucial context for interpreting the Quranic verses. This approach is known as 'Asbab al-Nuzul' (reasons for revelation) in Islamic scholarship.\n\nKnowing the historical context helps readers avoid misinterpretations that might occur when verses are read in isolation. It shows how the Quran engaged with real-world situations and provided guidance for specific challenges faced by the early Muslim community.",
-            imageUrl: "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F4D6.svg",
+            imageUrl: "/assets/book.svg",
           },
           {
             title: "Meccan vs. Medinan Revelations",
             content:
               "The Quran's chapters (surahs) are broadly categorized into Meccan (revealed before the migration to Medina) and Medinan (revealed after). These two periods had distinct characteristics that influenced the nature and focus of the revelations.\n\nMeccan revelations typically focus on fundamental beliefs, the oneness of God (tawhid), stories of previous prophets, and establishing core moral values. Medinan revelations, in contrast, contain more detailed legal rulings, guidance for the emerging Muslim society, and instructions regarding interactions with other faith communities.",
-            imageUrl: "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F4C5.svg",
+            imageUrl: "/assets/calendar.svg",
           },
           {
             title: "Case Study: Surah Al-Asr",
@@ -164,13 +164,13 @@ export const learningPlans: LearningPlan[] = [
             title: "The Linguistic Miracle",
             content:
               "The Quran's linguistic excellence is considered one of its miraculous aspects. Classical Arabic scholars have extensively documented its rhetorical devices, unique linguistic patterns, and literary coherence.\n\nThe Quran itself challenged its contemporaries to produce a chapter like it, despite addressing an audience renowned for their eloquence and poetic abilities. This linguistic inimitability (I'jaz) remains a central aspect of Quranic studies.",
-            imageUrl: "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F4A1.svg",
+            imageUrl: "/assets/linguistic-miracle.svg",
           },
           {
             title: "Key Literary Devices",
             content:
               "The Quran employs numerous literary devices including metaphor, simile, parallelism, and rhetorical questions. For example, in Surah Al-Rahman (Chapter 55), the repeated refrain 'So which of the favors of your Lord would you deny?' creates a powerful rhythmic effect while emphasizing divine blessings.\n\nUnderstanding these devices helps readers appreciate the artistry of the text and often reveals deeper layers of meaning that might be missed in translation.",
-            imageUrl: "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F4AC.svg",
+            imageUrl: "/assets/speech-bubble.svg",
           },
           {
             title: "Word Choice and Precision",
@@ -191,13 +191,13 @@ export const learningPlans: LearningPlan[] = [
             title: "Coherence Across Chapters",
             content:
               "Though revealed over 23 years in different contexts, the Quran maintains remarkable thematic coherence. Scholars of 'Nazm al-Quran' (Quranic coherence) have identified intricate connections between adjacent chapters and even between seemingly unrelated passages.\n\nThese connections create a web of meaning that transcends chronological order. Understanding these thematic links helps readers appreciate the Quran as a unified text rather than a collection of isolated revelations.",
-            imageUrl: "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F4D1.svg",
+            imageUrl: "/assets/bookmark.svg",
           },
           {
             title: "Recurring Themes",
             content:
               "Certain themes recur throughout the Quran, including stories of prophets, descriptions of the natural world as signs of God, ethical teachings, and eschatological narratives about the afterlife.\n\nBy tracking these themes across different chapters, readers can develop a more comprehensive understanding of how the Quran approaches these subjects from multiple angles. This thematic reading reveals nuances that might be missed when passages are read in isolation.",
-            imageUrl: "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F500.svg",
+            imageUrl: "/assets/shuffle.svg",
           },
           {
             title: "Case Study: Justice in the Quran",
@@ -228,13 +228,13 @@ export const learningPlans: LearningPlan[] = [
             title: "Overview of Surah al-Hadid",
             content:
               "Surah al-Hadid (The Iron) is the 57th chapter of the Quran, consisting of 29 verses. It is a Medinan surah, revealed after the Prophet's migration to Medina. The surah derives its name from the mention of iron (hadid) in verse 25, where Allah says: 'And We sent down iron, wherein is mighty power and benefits for mankind.'\n\nThis chapter is known for its profound discussions on faith, charity, and the nature of worldly life. It begins with the glorification of Allah and proceeds to discuss the creation of the heavens and earth, the omniscience of God, and the importance of spending in His cause.",
-            imageUrl: "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F6E0.svg",
+            imageUrl: "/assets/tools.svg",
           },
           {
             title: "Historical Context",
             content:
               "Surah al-Hadid was revealed in Medina at a time when the Muslim community was being established as a social and political entity. This context is important for understanding its emphasis on spending in the cause of Allah and its reminders about the temporary nature of worldly life.\n\nThe surah addresses both the early converts to Islam, reminding them of their commitment, and those who embraced Islam after the conquest of Mecca, encouraging them to contribute to the community. It was a period of transition from persecution to establishment, which is reflected in the surah's themes.",
-            imageUrl: "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F3DB.svg",
+            imageUrl: "/assets/building.svg",
           },
           {
             title: "Key Themes",
@@ -255,13 +255,13 @@ export const learningPlans: LearningPlan[] = [
             title: "Iron in Verse 25",
             content:
               "The key reference to iron in Surah al-Hadid occurs in verse 25, which states: 'We have certainly sent Our messengers with clear proofs and sent down with them the Scripture and the balance that the people may maintain [their affairs] in justice. And We sent down iron, wherein is mighty power and benefits for mankind...'\n\nThe Arabic phrase used is 'wa anzalna al-hadida' ('We sent down iron'), which has intrigued scholars both for its spiritual significance and its scientific implications. The surah highlights two key qualities of iron: its strength ('mighty power') and its utility ('benefits for mankind').",
-            imageUrl: "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/26CF.svg",
+            imageUrl: "/assets/pick.svg",
           },
           {
             title: "Scientific Perspectives",
             content:
               "Modern scientific understanding reveals fascinating aspects about iron that give deeper meaning to the Quranic phrase 'sent down' (anzalna). Unlike elements formed on Earth, the iron in our planet's crust and core originated from distant stars. Through supernova explosions, iron was scattered through space and eventually became incorporated into Earth during its formation.\n\nThis scientific fact aligns remarkably with the Quranic description of iron being 'sent down.' Iron plays a crucial role in Earth's magnetic field, which protects life from harmful radiation, and in the hemoglobin of our blood, which transports oxygen—truly embodying 'benefits for mankind' as mentioned in the surah.",
-            imageUrl: "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F52C.svg",
+            imageUrl: "/assets/microscope.svg",
           },
           {
             title: "Symbolic Meaning",
@@ -282,13 +282,13 @@ export const learningPlans: LearningPlan[] = [
             title: "Balancing Dunya and Akhirah",
             content:
               "Surah al-Hadid teaches us about maintaining balance between worldly concerns (dunya) and spiritual aspirations (akhirah). The surah warns against becoming so absorbed in material pursuits that we neglect our spiritual development, while also emphasizing that material strength (symbolized by iron) has an important place in the divine plan.\n\nPractical application involves regularly assessing how we allocate our time, energy, and resources between material and spiritual pursuits. This might include setting aside time for both work and worship, using wealth for both personal needs and charitable causes, and developing both professional skills and spiritual knowledge.",
-            imageUrl: "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/2696.svg",
+            imageUrl: "/assets/scales.svg",
           },
           {
             title: "Cultivating Generosity",
             content:
               "A major theme in Surah al-Hadid is spending in the way of Allah. Verses 10-11 specifically address the importance of charity and its rewards. The surah reminds us that everything ultimately belongs to Allah, and our wealth is a trust that we are expected to use wisely and generously.\n\nPractical steps include:\n\n1. Establishing regular charitable giving beyond obligatory zakat\n2. Being early in responding to calls for charity rather than delaying\n3. Giving with sincerity, seeking only Allah's pleasure rather than recognition\n4. Remembering that loans to the needy are 'loans to Allah' that will be repaid multiplied",
-            imageUrl: "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F4B5.svg",
+            imageUrl: "/assets/banknote.svg",
           },
           {
             title: "Developing Spiritual Resilience",
@@ -319,13 +319,13 @@ export const learningPlans: LearningPlan[] = [
             title: "The Reality of Post-Ramadan Decline",
             content:
               "Many Muslims experience a noticeable decline in their spiritual practice and motivation after Ramadan ends. This phenomenon, sometimes called the 'post-Ramadan slump,' is a common challenge that affects Muslims worldwide.\n\nDuring Ramadan, we benefit from communal support, special prayers, and a focused spiritual atmosphere. When these external motivators disappear, maintaining the same level of worship becomes more challenging. Understanding this pattern is the first step toward addressing it effectively.",
-            imageUrl: "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F4A4.svg",
+            imageUrl: "/assets/zzz.svg",
           },
           {
             title: "Psychological Perspectives",
             content:
               "From a psychological perspective, the post-Ramadan challenge can be understood through several frameworks:\n\n1. Habit Formation: Research suggests that habits take time to form—typically anywhere from 18 to 254 days, with an average of 66 days. The 29-30 days of Ramadan may not be enough to fully cement new spiritual habits.\n\n2. Social Reinforcement: The communal aspect of Ramadan provides strong social reinforcement that disappears afterward.\n\n3. Goal Setting: After achieving the 'completion' of Ramadan, many people lack clear spiritual goals for the following months.\n\nUnderstanding these psychological factors helps us develop more effective strategies for maintaining momentum.",
-            imageUrl: "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F9E0.svg",
+            imageUrl: "/assets/brain.svg",
           },
           {
             title: "The Islamic Perspective",
@@ -346,13 +346,13 @@ export const learningPlans: LearningPlan[] = [
             title: "The Science of Habit Formation",
             content:
               "Building sustainable spiritual habits requires understanding how habits form. According to researchers, habits consist of three components:\n\n1. Cue: A trigger that initiates the behavior\n2. Routine: The behavior itself\n3. Reward: The benefit gained from performing the behavior\n\nFor example, a spiritual habit might involve:\n- Cue: Hearing the adhan (call to prayer)\n- Routine: Performing the prayer\n- Reward: Feeling connected to Allah and at peace\n\nBy consciously designing these three elements, we can develop habits that continue long after Ramadan.",
-            imageUrl: "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F9EE.svg",
+            imageUrl: "/assets/abacus.svg",
           },
           {
             title: "Practical Habit Strategies",
             content:
               "To turn Ramadan practices into lasting habits, consider these practical approaches:\n\n1. Start Small: Rather than trying to maintain all Ramadan practices, choose 1-2 key practices to continue. For example, if you read Quran daily during Ramadan, commit to reading just one page daily after Ramadan.\n\n2. Anchor to Existing Habits: Connect new spiritual habits to already established routines. For example, read Quran after each fajr prayer or before going to bed.\n\n3. Create Environment Triggers: Design your environment to remind and facilitate spiritual practices. Keep a Quran visible in your living space, set prayer reminders on your phone, or display Islamic wall art as visual cues.\n\n4. Track Progress: Use a habit tracker app or journal to monitor consistency. Visual progress tracking provides motivation and accountability.\n\n5. Plan for Obstacles: Identify potential barriers to your spiritual habits and plan specific strategies to overcome them.",
-            imageUrl: "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F4CB.svg",
+            imageUrl: "/assets/clipboard.svg",
           },
           {
             title: "Developing a Personal Habit Plan",
@@ -373,13 +373,13 @@ export const learningPlans: LearningPlan[] = [
             title: "The Importance of Self-Reflection",
             content:
               "Regular self-reflection (muhasabah) is a well-established Islamic practice that helps maintain spiritual momentum after Ramadan. The second Caliph, Umar ibn al-Khattab, said: 'Take account of yourselves before you are taken to account.'\n\nSelf-reflection involves examining our thoughts, actions, and intentions against our spiritual values and goals. This practice helps us recognize patterns, celebrate progress, identify areas for improvement, and renew our intention (niyyah). Without regular reflection, we may drift from our spiritual path without noticing.",
-            imageUrl: "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F50D.svg",
+            imageUrl: "/assets/magnifying-glass.svg",
           },
           {
             title: "Structured Weekly Reflection Guide",
             content:
               "Develop a weekly reflection practice using the following structure:\n\n1. Review the week: Set aside 15-30 minutes at the same time each week (Friday evening is traditional in many cultures) to review your spiritual journey over the past seven days.\n\n2. Ask key questions: Reflect on questions such as:\n   - Did I fulfill my obligations (prayers, duties to family, ethical conduct)?\n   - What spiritual practices did I maintain consistently?\n   - Where did I struggle, and what were the circumstances?\n   - What patterns or triggers led to spiritual high points or low points?\n   - How did I treat others this week?\n\n3. Record insights: Keep a journal of your reflections to track patterns over time.\n\n4. Plan improvements: Based on your reflection, set 1-2 specific intentions for the coming week.\n\n5. Make dua (supplication): Conclude with gratitude to Allah for successes and asking for help with challenges.",
-            imageUrl: "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F4DD.svg",
+            imageUrl: "/assets/memo.svg",
           },
           {
             title: "Communal Reflection Practices",

--- a/client/src/pages/learn-plan-detail.tsx
+++ b/client/src/pages/learn-plan-detail.tsx
@@ -155,15 +155,11 @@ export default function LearningPlanDetail() {
                         
                         {section.imageUrl && (
                           <div className="mt-4 rounded-lg overflow-hidden bg-gray-50 dark:bg-gray-700 p-4 flex justify-center">
-                            <svg width="250" height="200" viewBox="0 0 250 200" xmlns="http://www.w3.org/2000/svg">
-                              <rect width="250" height="200" fill="#f8f9fa"/>
-                              <circle cx="125" cy="80" r="50" fill="#e3f2fd"/>
-                              <path d="M125 130 Q 75 180 125 180 Q 175 180 125 130" fill="#bbdefb"/>
-                              <text x="125" y="85" fontFamily="Arial" fontSize="14" fill="#1565c0" textAnchor="middle">{section.title}</text>
-                              <text x="125" y="105" fontFamily="Arial" fontSize="10" fill="#1565c0" textAnchor="middle">
-                                {`Illustration for ${section.title}`}
-                              </text>
-                            </svg>
+                            <img
+                              src={section.imageUrl}
+                              alt={section.title}
+                              className="max-h-48 w-auto object-contain"
+                            />
                           </div>
                         )}
                         


### PR DESCRIPTION
## Summary
- swap placeholder illustration for real lesson images in learn plan detail
- reference local SVG assets for all lesson image URLs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688acc3b21cc832a84ad46b3f7abf903