### PR TITLE
build: compile service worker and use manifest

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -9,7 +9,7 @@ import { queryClient } from "./lib/queryClient";
 if ("serviceWorker" in navigator) {
   window.addEventListener("load", () => {
     navigator.serviceWorker
-      .register("/src/service-worker.ts")
+      .register("/service-worker.js")
       .then((registration) => {
         console.log("Service Worker registered with scope:", registration.scope);
       })

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
-    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "vite build && cp dist/public/.vite/manifest.json dist/public/manifest.json && esbuild client/src/service-worker.ts --platform=browser --bundle --format=iife --outfile=dist/public/service-worker.js && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "test": "jest",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,5 +27,6 @@ export default defineConfig({
   build: {
     outDir: path.resolve(import.meta.dirname, "dist/public"),
     emptyOutDir: true,
+    manifest: true,
   },
 });


### PR DESCRIPTION
## Summary
- replace hard-coded cache list with manifest-driven asset caching in the service worker
- emit build manifest and compile service worker JS during build process
- register built service worker path in main entry

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688c215cf654832a80a529b4d42da0cc