### PR TITLE
Use authenticated APIs for streak and achievements

### DIFF
--- a/client/src/components/home/quran-growth-journey.tsx
+++ b/client/src/components/home/quran-growth-journey.tsx
@@ -3,7 +3,6 @@ import { useStreak } from "@/hooks/use-streak";
 import { useAchievements } from "@/hooks/use-achievements";
 
 export default function QuranGrowthJourney() {
-  // We'll use placeholder data for now and integrate with real data from API later
   const { streak, pagesRead } = useStreak();
   const { achievements } = useAchievements();
   


### PR DESCRIPTION
## Summary
- Fetch streak and reading progress via authenticated `apiRequest`
- Invalidate achievements on streak or reading updates
- Remove placeholder comment from Quran Growth Journey component

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688c216149dc832a818ae01240eb9bca