### PR TITLE
refactor: gate replit banner to development

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -38,7 +38,13 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
-    <!-- This is a replit script which adds a banner on the top of the page when opened in development mode outside the replit environment -->
-    <script type="text/javascript" src="https://replit.com/public/js/replit-dev-banner.js"></script>
+    <!-- Load Replit dev banner only during local development -->
+    <script type="module">
+      if (import.meta.env.DEV) {
+        const script = document.createElement("script");
+        script.src = "https://replit.com/public/js/replit-dev-banner.js";
+        document.body.appendChild(script);
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- load Replit banner only when `import.meta.env.DEV`

## Testing
- `npm test`
- `npm run check` *(fails: Type '"ahmad"' is not assignable ...)*

------
https://chatgpt.com/codex/tasks/task_e_688c26cc8d78832a89f986e26cf237cd