### PR TITLE
Require SESSION_SECRET environment variable

### DIFF
--- a/deploy-app-store.md
+++ b/deploy-app-store.md
@@ -12,6 +12,7 @@ PWABuilder's Windows package generation currently has a bug with SVG icons that 
 - Node.js 18+
 - App store developer accounts
 - PWA Builder CLI or similar tools
+- SESSION_SECRET environment variable configured for session management
 
 ## Build Process
 

--- a/replit.md
+++ b/replit.md
@@ -98,6 +98,7 @@ The application is configured for deployment on Replit:
 3. **Production Serving**: Express serves the static frontend and API endpoints
 4. **Database**: Uses PostgreSQL (as indicated by the Replit configuration)
 5. **Scaling**: Configured for autoscaling via Replit's deployment options
+6. **Environment Variables**: Set `SESSION_SECRET` for secure session handling
 
 ## Development Workflow
 

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -33,6 +33,10 @@ async function createSessionTable() {
 export function setupAuth(app: express.Express) {
   // Create session table
   createSessionTable();
+  const sessionSecret = process.env.SESSION_SECRET;
+  if (!sessionSecret) {
+    throw new Error("SESSION_SECRET environment variable is required");
+  }
 
   // Session middleware
   app.use(
@@ -41,7 +45,7 @@ export function setupAuth(app: express.Express) {
         pool,
         tableName: 'session', // Use the session table
       }),
-      secret: process.env.SESSION_SECRET || 'myquran-secret-key',
+      secret: sessionSecret,
       resave: false,
       saveUninitialized: false,
       cookie: {


### PR DESCRIPTION
## Summary
- enforce `SESSION_SECRET` presence and remove hardcoded default
- document required `SESSION_SECRET` for deployment

## Testing
- `CI=true SESSION_SECRET=test npm test`
- `npm run check` *(fails: 'hadiths' is of type 'unknown', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_688c26cfb3cc832abf0f9c0a76128d8c