### PR TITLE
feat: secure AI chat with auth and rate limiting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "drizzle-zod": "^0.7.0",
         "embla-carousel-react": "^8.6.0",
         "express": "^4.21.2",
+        "express-rate-limit": "^7.5.1",
         "express-session": "^1.18.1",
         "framer-motion": "^11.13.1",
         "input-otp": "^1.4.2",
@@ -7569,6 +7570,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/express-session": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "drizzle-zod": "^0.7.0",
     "embla-carousel-react": "^8.6.0",
     "express": "^4.21.2",
+    "express-rate-limit": "^7.5.1",
     "express-session": "^1.18.1",
     "framer-motion": "^11.13.1",
     "input-otp": "^1.4.2",

--- a/server/openai-routes.ts
+++ b/server/openai-routes.ts
@@ -15,11 +15,17 @@ Always maintain a tone of respect when discussing religious matters.
 If you don't know something or are uncertain, acknowledge that rather than providing potentially incorrect information.
 `;
 
+const MAX_INPUT_LENGTH = 500;
+
 export async function getAIResponse(req: Request, res: Response) {
   const { message } = req.body;
-  
-  if (!message) {
+
+  if (!message || typeof message !== "string") {
     return res.status(400).json({ error: "Message is required" });
+  }
+
+  if (message.length > MAX_INPUT_LENGTH) {
+    return res.status(400).json({ error: `Message is too long. Max length is ${MAX_INPUT_LENGTH} characters.` });
   }
   
   try {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -10,6 +10,7 @@ import { setupAuth, isAuthenticated } from "./auth";
 import { AchievementService } from "./achievement-service";
 import cookieParser from "cookie-parser";
 import path from "path";
+import rateLimit from "express-rate-limit";
 
 export async function registerRoutes(app: Express): Promise<Server> {
   // Set up middlewares
@@ -630,8 +631,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  // OpenAI routes
-  app.post("/api/ai/chat", getAIResponse);
+  // AI chat route (authenticated users only).
+  // Limited to 5 requests per minute per IP and messages up to 500 characters.
+  const aiLimiter = rateLimit({ windowMs: 60 * 1000, max: 5 });
+  app.post("/api/ai/chat", isAuthenticated, aiLimiter, getAIResponse);
 
   // Create HTTP server
   const httpServer = createServer(app);


### PR DESCRIPTION
## Summary
- protect AI chat route with auth and express-rate-limit
- validate AI input length before sending to OpenAI
- document AI usage quota in route comment and add express-rate-limit dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c26d028f8832a9a354b5c70384c23