### PR TITLE
Protect user-specific routes with authentication

### DIFF
--- a/client/src/hooks/use-streak.ts
+++ b/client/src/hooks/use-streak.ts
@@ -32,7 +32,7 @@ export function useStreak(userId?: number) {
   useEffect(() => {
     if (effectiveUserId) {
       setIsLoading(true);
-      fetch(`/api/streaks/${effectiveUserId}`)
+      fetch(`/api/streaks`, { credentials: "include" })
         .then(res => {
           if (!res.ok) throw new Error("Failed to fetch streak data");
           return res.json();
@@ -51,9 +51,9 @@ export function useStreak(userId?: number) {
         .finally(() => {
           setIsLoading(false);
         });
-        
+
       // Also fetch pages read
-      fetch(`/api/reading-progress/${effectiveUserId}`)
+      fetch(`/api/reading-progress`, { credentials: "include" })
         .then(res => {
           if (!res.ok) throw new Error("Failed to fetch reading progress");
           return res.json();
@@ -121,7 +121,6 @@ export function useStreak(userId?: number) {
     // Update via API if authenticated
     try {
       const response = await apiRequest("POST", "/api/streaks", {
-        userId: effectiveUserId,
         currentStreak: newStreak,
         longestStreak: newLongestStreak,
         lastReadDate: today,
@@ -174,7 +173,6 @@ export function useStreak(userId?: number) {
     // Create reading progress entry in database
     try {
       const response = await apiRequest("POST", "/api/reading-progress", {
-        userId: effectiveUserId,
         surahId: surahId || 1,
         lastReadAyah: ayahNumber || 1,
         pagesRead: pages,

--- a/client/src/pages/learn-plan-detail.tsx
+++ b/client/src/pages/learn-plan-detail.tsx
@@ -42,14 +42,15 @@ export default function LearningPlanDetail() {
         return await fetch(`/api/reflections/${existingReflection.id}`, {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
+          credentials: "include",
           body: JSON.stringify({ content: noteData.content }),
         }).then(res => res.json());
       } else {
         return await fetch("/api/reflections", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
+          credentials: "include",
           body: JSON.stringify({
-            userId: (user as any)?.id,
             title: `${plan?.title} - Learning Notes`,
             content: noteData.content,
             isPrivate: true,

--- a/client/src/pages/profile-goals.tsx
+++ b/client/src/pages/profile-goals.tsx
@@ -25,10 +25,7 @@ export default function ProfileGoals() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
-        body: JSON.stringify({
-          userId: user?.id,
-          ...goalData,
-        }),
+        body: JSON.stringify(goalData),
       });
       
       if (!response.ok) {

--- a/server/pg-storage.ts
+++ b/server/pg-storage.ts
@@ -143,9 +143,9 @@ export class PgStorage implements IStorage {
       .where(eq(bookmarks.userId, userId));
   }
 
-  async deleteBookmark(id: number): Promise<boolean> {
+  async deleteBookmark(id: number, userId: number): Promise<boolean> {
     const result = await db.delete(bookmarks)
-      .where(eq(bookmarks.id, id))
+      .where(and(eq(bookmarks.id, id), eq(bookmarks.userId, userId)))
       .returning();
     return result.length > 0;
   }
@@ -164,17 +164,17 @@ export class PgStorage implements IStorage {
       .where(eq(reflections.userId, userId));
   }
 
-  async updateReflection(id: number, reflection: Partial<InsertReflection>): Promise<Reflection | undefined> {
+  async updateReflection(id: number, userId: number, reflection: Partial<InsertReflection>): Promise<Reflection | undefined> {
     const [updated] = await db.update(reflections)
       .set(reflection)
-      .where(eq(reflections.id, id))
+      .where(and(eq(reflections.id, id), eq(reflections.userId, userId)))
       .returning();
     return updated;
   }
 
-  async deleteReflection(id: number): Promise<boolean> {
+  async deleteReflection(id: number, userId: number): Promise<boolean> {
     const result = await db.delete(reflections)
-      .where(eq(reflections.id, id))
+      .where(and(eq(reflections.id, id), eq(reflections.userId, userId)))
       .returning();
     return result.length > 0;
   }


### PR DESCRIPTION
## Summary
- secure user-focused APIs like reading progress, streaks, achievements, goals, bookmarks, reflections, and user quests by requiring `isAuthenticated` and pulling the ID from `req.user`
- ensure deletions and updates of bookmarks and reflections are scoped to the logged-in user in storage layer
- update client hooks and pages to call the new authenticated endpoints without sending `userId`

## Testing
- `npm test`
- `npm run check` *(fails: Type '"ahmad"' is not assignable to type ...)*

------
https://chatgpt.com/codex/tasks/task_e_688c215c0284832aab8f583c261aca58