### PR TITLE
fix: refine streak data retrieval

### DIFF
--- a/client/src/hooks/use-streak.ts
+++ b/client/src/hooks/use-streak.ts
@@ -55,7 +55,7 @@ export function useStreak(userId?: number) {
         .then(data => {
           // Calculate total pages read
           const total = data.reduce((sum: number, progress: any) => {
-            return sum + (progress.pagesRead || 1);
+            return sum + (progress.pagesRead ?? 1);
           }, 0);
           setPagesRead(total);
         })


### PR DESCRIPTION
## Summary
- use apiRequest to load streak and reading progress data
- ensure pages read math is null-safe

## Testing
- `npm test`
- `npm run check` *(fails: 'hadiths' is of type 'unknown')*

------
https://chatgpt.com/codex/tasks/task_e_688c2b34e9cc832aa9c95f69824ae2a0