### PR TITLE
Add server route tests and update test scripts

### DIFF
--- a/jest.server.config.js
+++ b/jest.server.config.js
@@ -1,0 +1,17 @@
+export default {
+  preset: 'ts-jest/presets/js-with-ts-esm',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/server/tests'],
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@shared/(.*)$': '<rootDir>/shared/$1',
+  },
+  globals: {
+    'ts-jest': {
+      tsconfig: './tsconfig.jest.json',
+      useESM: true,
+      diagnostics: false,
+    },
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,6 +100,7 @@
         "@types/passport-local": "^1.0.38",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.1",
+        "@types/supertest": "^6.0.3",
         "@types/ws": "^8.5.13",
         "@vitejs/plugin-react": "^4.3.2",
         "autoprefixer": "^10.4.20",
@@ -108,6 +109,7 @@
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^30.0.5",
         "postcss": "^8.4.47",
+        "supertest": "^7.1.4",
         "tailwindcss": "^3.4.17",
         "ts-jest": "^29.4.0",
         "tsx": "^4.19.1",
@@ -2480,6 +2482,19 @@
         "@types/pg": "8.11.6"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2513,6 +2528,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -4604,6 +4629,13 @@
         "@types/express": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
@@ -4808,6 +4840,13 @@
       "integrity": "sha512-EdtpwNYNhe3kZ+4TlXj/++pvBoU0KdrAICMzgI7vjWgu9sIvvUhu9XR8Ks4L6Wh3sxpZ22wkZR7yCLAqUjnZuQ==",
       "license": "MIT"
     },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -4944,6 +4983,30 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.3.tgz",
+      "integrity": "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
@@ -5164,6 +5227,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/async": {
@@ -5912,6 +5982,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5994,6 +6074,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/create-jest": {
@@ -6450,6 +6537,17 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -7703,6 +7801,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -7837,14 +7942,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -7868,6 +7974,24 @@
       },
       "engines": {
         "node": ">= 12.20"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -13050,6 +13174,54 @@
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.3.tgz",
+      "integrity": "sha512-y/hkYGeXAj7wUMjxRbB21g/l6aAEituGXM9Rwl4o20+SX3e8YOSV6BxFXl+dL3Uk0mjSL3kCbNkwURm8/gEDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.4",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.2"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.4.tgz",
+      "integrity": "sha512-tjLPs7dVyqgItVFirHYqe2T+MfWc2VOBQ8QFKKbWTA3PU7liZR8zoSpAi/C1k1ilm9RsXIKYf197oap9wXGVYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^10.2.3"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "vite build && cp dist/public/.vite/manifest.json dist/public/manifest.json && esbuild client/src/service-worker.ts --platform=browser --bundle --format=iife --outfile=dist/public/service-worker.js && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "test": "jest",
+    "test": "npm run test:client && npm run test:server",
+    "test:client": "jest --config jest.config.js",
+    "test:server": "jest --config jest.server.config.js",
     "db:push": "drizzle-kit push"
   },
   "dependencies": {
@@ -103,6 +105,7 @@
     "@types/passport-local": "^1.0.38",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.1",
+    "@types/supertest": "^6.0.3",
     "@types/ws": "^8.5.13",
     "@vitejs/plugin-react": "^4.3.2",
     "autoprefixer": "^10.4.20",
@@ -111,6 +114,7 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.0.5",
     "postcss": "^8.4.47",
+    "supertest": "^7.1.4",
     "tailwindcss": "^3.4.17",
     "ts-jest": "^29.4.0",
     "tsx": "^4.19.1",

--- a/server/tests/routes.test.ts
+++ b/server/tests/routes.test.ts
@@ -1,0 +1,108 @@
+/** @jest-environment node */
+import request from 'supertest';
+import express from 'express';
+
+jest.mock('../pg-storage', () => {
+  const sampleProgress = { userId: 1, surahId: 1, lastReadAyah: 5, isCompleted: false };
+  return {
+    PgStorage: jest.fn().mockImplementation(() => ({
+      createOrUpdateReadingProgress: jest.fn().mockResolvedValue(sampleProgress),
+      getReadingProgressByUserId: jest.fn().mockResolvedValue([sampleProgress]),
+      getHadithsByCollection: jest.fn().mockResolvedValue(new Array(100).fill({})),
+      createHadith: jest.fn(),
+    })),
+  };
+});
+
+jest.mock('../achievement-service', () => {
+  return {
+    AchievementService: jest.fn().mockImplementation(() => ({
+      onAyahRead: jest.fn().mockResolvedValue([]),
+      onSurahCompleted: jest.fn().mockResolvedValue([]),
+      onHadithRead: jest.fn().mockResolvedValue([]),
+      onDuaLearned: jest.fn().mockResolvedValue([]),
+    })),
+  };
+});
+
+jest.mock('../auth', () => ({
+  setupAuth: jest.fn(),
+  isAuthenticated: (_req: any, _res: any, next: any) => next(),
+}));
+
+jest.mock('../openai-routes', () => ({
+  getAIResponse: jest.fn(),
+}));
+
+jest.mock('../hadith-data', () => ({ BUKHARI_VOLUME_1: [] }));
+jest.mock('../complete-hadith-data', () => ({
+  COMPLETE_HADITH_COLLECTION: [],
+  NAWAWI_FORTY_HADITH: [],
+  MUSLIM_HADITH_SAMPLE: [],
+}));
+
+jest.mock('../complete-dua-collection', () => ({
+  COMPLETE_DUA_COLLECTION: [
+    { id: '1', category: 'Daily Routine', text: 'Sample Dua 1' },
+    { id: '2', category: 'Prayer', text: 'Sample Dua 2' },
+  ],
+  DUA_CATEGORIES: ['Daily Routine', 'Prayer'],
+  FEATURED_DUAS: ['1'],
+}));
+
+jest.mock('../db', () => ({
+  handleDbError: (e: any) => e,
+}));
+
+import { registerRoutes } from '../routes';
+
+describe('API routes', () => {
+  let app: express.Express;
+
+  beforeAll(async () => {
+    app = express();
+    app.use(express.json());
+    app.use(express.urlencoded({ extended: false }));
+    await registerRoutes(app);
+  });
+
+  describe('Reading Progress', () => {
+    it('creates reading progress', async () => {
+      const res = await request(app)
+        .post('/api/reading-progress')
+        .send({ userId: 1, surahId: 1, lastReadAyah: 5, isCompleted: false });
+      expect(res.status).toBe(201);
+      expect(res.body.progress).toEqual({ userId: 1, surahId: 1, lastReadAyah: 5, isCompleted: false });
+    });
+
+    it('retrieves reading progress for user', async () => {
+      const res = await request(app).get('/api/reading-progress/1');
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([
+        { userId: 1, surahId: 1, lastReadAyah: 5, isCompleted: false },
+      ]);
+    });
+  });
+
+  describe('Dua routes', () => {
+    it('returns all duas', async () => {
+      const res = await request(app).get('/api/duas');
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(2);
+    });
+
+    it('filters duas by category', async () => {
+      const res = await request(app).get('/api/duas').query({ category: 'prayer' });
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([
+        { id: '2', category: 'Prayer', text: 'Sample Dua 2' },
+      ]);
+    });
+
+    it('returns dua by id', async () => {
+      const res = await request(app).get('/api/duas/1');
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ id: '1', category: 'Daily Routine', text: 'Sample Dua 1' });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest config for server tests
- add tests for reading progress and dua endpoints with mocked storage
- run client and server tests via unified npm script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cbe27a8b4832abf7fc6225e6e05ad