### PR TITLE
docs: add environment example and update docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Database connection string
+DATABASE_URL=
+
+# API key for OpenAI integration
+OPENAI_API_KEY=
+
+# Secret used to sign session cookies
+SESSION_SECRET=
+
+# Node environment, e.g. 'development' or 'production'
+NODE_ENV=development

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ server/public
 vite.config.ts.*
 *.tar.gz
 attached_assets/
+
+# Environment variables (copy from .env.example)
+.env
+.env.*
+!.env.example

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# QuranTracker
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in the required values:
+
+- `DATABASE_URL` – Database connection string.
+- `OPENAI_API_KEY` – API key for OpenAI integration.
+- `SESSION_SECRET` – Secret used to sign session cookies.
+- `NODE_ENV` – Node environment mode, e.g. `development` or `production`.


### PR DESCRIPTION
## Summary
- add `.env.example` with required configuration variables
- document environment setup in README
- ignore local `.env` files while keeping example committed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cbe25b580832a847b2a6b10994d2f